### PR TITLE
Fixed Uncaught TypeError

### DIFF
--- a/tableHeadFixer.js
+++ b/tableHeadFixer.js
@@ -244,7 +244,7 @@
 				var cell = $(row).find("> *:nth-child(" + nth + ")");
 				var colspan = cell.prop("colspan");
 
-				if (cell.cellPos().left < fixColumn) {
+				if (cell.length > 0 && cell.cellPos().left < fixColumn) {
 					action(cell);
 				}
 


### PR DESCRIPTION
Uncaught TypeError: Cannot read property 'left' of null tableHeadFixer.js?body=1:247

Check that the "cell" variable actually contains something before calling a method on it.

It broke my page's JS when my dynamically generated table didn't have enough columns to need to be fixed. This small change fixed my problem.