### PR TITLE
Fix bug related to a probable undefined value

### DIFF
--- a/tableHeadFixer.js
+++ b/tableHeadFixer.js
@@ -226,7 +226,7 @@
                     var cell = $(row).find("> *:nth-child(" + nth + ")");
                     var colspan = cell.prop("colspan");
 
-                    if (cell.cellPos().left < fixColumn) {
+                    if (typeof cell.cellPos() != 'undefined' && cell.cellPos().left < fixColumn) {
                         action(cell);
                     }
 


### PR DESCRIPTION
It has been noted that the value cell.cellPos() has the possibility to return undefined making the plugin fail